### PR TITLE
fix: [table]修复分组列收起后,拖拽列宽鼠标位置不正确 bug

### DIFF
--- a/components/table/demo/a70_columnGroup.md
+++ b/components/table/demo/a70_columnGroup.md
@@ -77,7 +77,7 @@ function Demo() {
       ]
     }
   ]
-  return <Table className="bordered" dataSource={dataSource} columns={columns} columnResizeable={true} columnGroupExtend={{extendStatus:expandStatus,onChangeExtendStatus:onChangeExtendStatus}}/>
+  return <Table className="bordered" dataSource={dataSource} columns={columns} columnResize={true} columnGroupExtend={{extendStatus:expandStatus,onChangeExtendStatus:onChangeExtendStatus}}/>
 }
 
 ReactDOM.render(<Demo />, mountNode)

--- a/components/table/table.tsx
+++ b/components/table/table.tsx
@@ -103,13 +103,13 @@ const Table = forwardRef<unknown, TableProps>((props: TableProps, ref) => {
   useSort(pipeline, sort)
   useAutoRowSpan(pipeline, autoRowSpan)
   useTreeMode(pipeline, treeMode)
+  usecolGroupExtendable(pipeline, columnGroupExtend)
   useColumnResize(pipeline, columnResize)
   useColumnDrag(pipeline, columnDrag)
   useContextMenu(pipeline, contextMenu)
   useRangeSelection(pipeline, rangeSelection)
   useＭergeCellHover(pipeline)
   useFooterDataSource(pipeline, footerDataSource)
-  usecolGroupExtendable(pipeline, columnGroupExtend)
 
   /* -------------------------------------------------------------------------- */
   /* after useTablePipeline, merge pipeline.getProps result                     */


### PR DESCRIPTION
列分组的 feature 需要在拖拽之前调用，才能让column 的数据正确