### PR TITLE
docs: a41_cellSpanWithSelect 鼠标事件选用onMouseEnter,点击是触发点击事件后不会再触发鼠标进入事件…

### DIFF
--- a/components/table/demo/a41_cellSpanWithSelect.md
+++ b/components/table/demo/a41_cellSpanWithSelect.md
@@ -40,7 +40,7 @@ function Demo() {
       }
       return {
         'data-row-id': record.id,
-        onMouseEnter: createHoverHandle((key, tbody) => {
+        onMouseOver: createHoverHandle((key, tbody) => {
           tbody.querySelector(`tr[data-row-id="${key}"]`).classList.add('row-hover')
         }),
         onMouseLeave: createHoverHandle((key, tbody) => {

--- a/components/table/demo/a41_cellSpanWithSelect.md
+++ b/components/table/demo/a41_cellSpanWithSelect.md
@@ -39,6 +39,7 @@ function Demo() {
           }
       }
       return {
+        'className': 'row-hover',
         'data-row-id': record.id,
         onMouseOver: createHoverHandle((key, tbody) => {
           tbody.querySelector(`tr[data-row-id="${key}"]`).classList.add('row-hover')


### PR DESCRIPTION
docs: a41_cellSpanWithSelect 鼠标事件选用onMouseEnter,点击是触发点击事件后不会再触发鼠标进入事件； 改用onMouseOver， 点击触发后 鼠标仍在原地，会继续触发mouseOver事件 fix : kdcloudone#350