### PR TITLE
fix:[CityPicker] 城市选择器 先选择其他组(ABCD)再选回【常用】组，【常用】组的 选中样式(active)没有生效 h…

### DIFF
--- a/components/city-picker/city-panel.tsx
+++ b/components/city-picker/city-panel.tsx
@@ -105,6 +105,7 @@ const CityPanel: React.FC<CityPanelProps> = ({ groups, commons, cityList, onSele
     if (commons && currentGroup === cityPickerLang.common) {
       setList([commons[activedIndex] || []])
       setGroupKeys(null)
+      setActivedGroupIndex(index)
       return
     }
 


### PR DESCRIPTION
城市选择器 先选择其他组(ABCD)再选回【常用】组，【常用】组的 选中样式(active)没有生效 handleGroupChange 方法 选中常用组时提前return方法，没有调用setActivedGroupIndex方法设置该组为选中状态  fixes: kdcloudone#362