### PR TITLE
[fix][CityPicker] 城市选择器 常用数据较少时 kd-city-picker-city-table 高度没有撑满，与其他分组的高度不一致 fixes: kdcloudone#365

### DIFF
--- a/components/city-picker/style/index.less
+++ b/components/city-picker/style/index.less
@@ -177,6 +177,7 @@
   margin-top: 10px;
   max-height: ~'calc(100% - 39px - 10px)';
   overflow: scroll;
+  height: 100%;
 
   .@{city-picker-prefix-cls}-city-table-group {
     display: flex;


### PR DESCRIPTION
[fix][CityPicker] 城市选择器 常用数据较少时 kd-city-picker-city-table 高度没有撑满，与其他分组的高度不一致 fixes: kdcloudone#365