### PR TITLE
[bug][input] 解决input输入框border可见时 prefix图标与左边框的margin距离过小的问题 fixes: #392

### DIFF
--- a/components/input/style/index.less
+++ b/components/input/style/index.less
@@ -129,6 +129,7 @@ textarea {
 
       &-prefix {
         margin-right: 4px;
+        margin-left: 8px;
       }
     }
 


### PR DESCRIPTION
[bug][input] 解决input输入框border可见时 prefix图标与左边框的margin距离过小的问题 fixes: #392