### PR TITLE
[bug][document] 解决主页header版本号与实际最新版本号不一致的问题 fixes:  #434

### DIFF
--- a/site/src/template/layout/header/index.tsx
+++ b/site/src/template/layout/header/index.tsx
@@ -10,6 +10,7 @@ import './index.less'
 import logo from './../../../static/image/logo.svg'
 import Search from './../../../static/image/top_search.png'
 import Login from './login'
+import { version as kdesignVersion } from '../../../../../package.json'
 // import Version from './version'
 
 const appIdQS = 'J5MHBTB51H'
@@ -90,7 +91,7 @@ const Header = (props: NavProps) => {
             <Nav list={navList} pathname={pathname} />
             <div className="header-search">
               <DocsSearch appId={appIdQS} indexName={indexNameQS} apiKey={apiKeyQS} transformData={transformData} />
-              <div className="header-version">v 1.7.13</div>
+              <div className="header-version">{kdesignVersion}</div>
               <a
                 href="https://github.com/kdcloudone/kdesign"
                 rel="noreferrer"


### PR DESCRIPTION
[bug][document] 解决主页header版本号与实际最新版本号不一致的问题 fixes:  #434 解决方法：引用package.json中的版本号，不适用魔法值